### PR TITLE
Support Multi-Object Delete

### DIFF
--- a/simples3/bucket.py
+++ b/simples3/bucket.py
@@ -230,10 +230,12 @@ class S3Bucket(object):
         if key:
             url += aws_urlquote(key)
         if args:
-            if hasattr(args, "iteritems"):
-                args = args.iteritems()
-            args = ((quote_plus(k), quote_plus(v)) for (k, v) in args)
-            url += "?" + arg_sep.join("%s=%s" % i for i in args)
+            if not isinstance(args, str):
+                if hasattr(args, "iteritems"):
+                    args = args.iteritems()
+                args = ((quote_plus(k), quote_plus(v)) for (k, v) in args)
+                args = arg_sep.join("%s=%s" % i for i in args)
+            url += "?" + args
         return url
 
     def open_request(self, request):

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -164,6 +164,13 @@ class DeleteTests(S3BucketTestCase):
         req = g.bucket.mock_requests[-1]
         eq_(req.get_method(), "DELETE")
 
+    def test_delete_multi_object(self):
+        expected = ('<?xml version="1.0" encoding="UTF-8"?>\n'
+                    '<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-'
+                    '03-01/"></DeleteResult>')
+        g.bucket.add_resp("/?delete", g.H("application/xml"), expected)
+        assert g.bucket.delete("foo.txt", "bar.txt", "baz.txt")
+
     def test_delete_not_found(self):
         g.bucket.add_resp("/foo.txt", g.H("application/xml"),
                           "<notfound />", status="404 Not Found")


### PR DESCRIPTION
Late last year [AWS S3 announced Multi-Object Delete](http://aws.amazon.com/about-aws/whats-new/2011/12/07/amazon-s3-announces-multi-object-delete/) that allows to delete up to 1,000 objects with a single request.

This patch makes `delete()` method able to take one or more keys (up to 1,000) and fixes a trivial bug of authorization for sub-resource access.

I did want to write a documentation for it also, but I can’t find reStructuredText files.
