### PR TITLE
Fixed #10 — S3Bucket.listdir() method raise UnboundLocalError sometimes

### DIFF
--- a/simples3/bucket.py
+++ b/simples3/bucket.py
@@ -127,7 +127,6 @@ class S3Request(object):
         "Sign the request with credentials *cred*."
         desc = self.descriptor()
         key = cred.secret_key.encode("utf-8")
-        print repr(key), repr(desc)
         hasher = hmac.new(key, desc.encode("utf-8"), hashlib.sha1)
         sign = b64encode(hasher.digest())
         self.headers["Authorization"] = "AWS %s:%s" % (cred.access_key, sign)


### PR DESCRIPTION
`S3Bucket.listdir()` method raised `UnboundLocalError` when the result list is empty.  This patch fixes the bug.  You can reproduce the bug by running following code:

``` python
from simples3.bucket import S3Bucket

S3_BUCKET_NAME = '...'
S3_ACCESS_KEY = '...'
S3_SECRET_KEY = '...'

bucket = S3Bucket(S3_BUCKET_NAME, S3_ACCESS_KEY, S3_SECRET_KEY)

# The above code works well both.
for x in bucket.listdir(prefix='existing-prefix'):
    print x

# The above code works only after this patch.
for x in bucket.listdir(prefix='not-existing-prefix'):
    print x
```

This bug fix has done by Hyunjun Kim, an employee of my company.  Thank you!
