### PR TITLE
put_file() persists request headers across multiple invocations

### DIFF
--- a/simples3/streaming.py
+++ b/simples3/streaming.py
@@ -47,6 +47,7 @@ class StreamingMixin(object):
         size, and ``last_read`` is how much was last read. ``last_read`` is
         zero on EOF.
         """
+        headers = headers.copy()
         do_close = False
         if not hasattr(fp, "read"):
             fp = open(fp, "rb")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,6 +11,7 @@ except ImportError:
     from cStringIO import StringIO as BytesIO
 
 import simples3
+import simples3.streaming
 from simples3.utils import rfc822_fmtdate
 
 # httplib.HTTPMessage is useless for mocking contexts, use own
@@ -94,6 +95,9 @@ class MockBucket(simples3.S3Bucket):
         self.mock_responses[:] = []
         self.mock_requests[:] = []
 
+class MockStreamingBucket(MockBucket, simples3.streaming.StreamingS3Bucket):
+    pass
+
 g = type("Globals", (object,), {})()
 
 def setup_package():
@@ -102,9 +106,14 @@ def setup_package():
         access_key="0PN5J17HBGZHT7JJ3X82",
         secret_key="uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o",
         base_url="http://johnsmith.s3.amazonaws.com")
+    g.streaming_bucket = MockStreamingBucket("johnsmith",
+        access_key="0PN5J17HBGZHT7JJ3X82",
+        secret_key="uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o",
+        base_url="http://johnsmith.s3.amazonaws.com")
 
 def teardown_package():
     del g.bucket
+    del g.streaming_bucket
 
 def H(ctype, *hpairs):
     n = datetime.datetime.now()

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1,5 +1,6 @@
 from __future__ import with_statement
 
+import StringIO
 import urllib2
 import unittest
 import datetime
@@ -22,9 +23,12 @@ def test_rfc822():
 class S3BucketTestCase(unittest.TestCase):
     def setUp(self):
         g.bucket.mock_reset()
+        g.streaming_bucket.mock_reset()
 
     def tearDown(self):
         if g.bucket.mock_responses:
+            raise RuntimeError("test run without exhausting mock_responses")
+        if g.streaming_bucket.mock_responses:
             raise RuntimeError("test run without exhausting mock_responses")
 
 class MiscTests(S3BucketTestCase):
@@ -130,14 +134,46 @@ class InfoTests(S3BucketTestCase):
         assert "foobar.txt" not in g.bucket
 
 class PutTests(S3BucketTestCase):
+    def _verify_headers(self, contents, headers):
+        assert "Content-length" in headers
+        assert str(len(contents)) == headers['Content-length']
+        assert "Content-type" in headers
+        assert "Content-md5" in headers
+        content_md5 = aws_md5(contents.encode("ascii"))
+        assert content_md5 == headers['Content-md5']
+        assert "Authorization" in headers
+
+    def _put_contents(self, key, contents):
+        g.bucket.add_resp("/%s" % key, g.H("application/xml"), "OK!")
+        g.bucket[key] = contents
+        self._verify_headers(contents, g.bucket.mock_requests[-1].headers)
+
+    def _put_file_contents(self, key, contents):
+        g.streaming_bucket.add_resp("/%s" % key, g.H("application/xml"), "OK!")
+
+        try:
+            fp = StringIO.StringIO()
+            fp.write(contents)
+            g.streaming_bucket.put_file(key, fp, size=len(contents))
+        finally:
+            fp.close()
+
+        self._verify_headers(contents,
+                             g.streaming_bucket.mock_requests[-1].headers)
+
     def test_put(self):
-        g.bucket.add_resp("/foo.txt", g.H("application/xml"), "OK!")
-        g.bucket["foo.txt"] = "hello"
-        hdrs = set(v.lower() for v in g.bucket.mock_requests[-1].headers)
-        assert "content-length" in hdrs
-        assert "content-type" in hdrs
-        assert "content-md5" in hdrs
-        assert "authorization" in hdrs
+        self._put_contents("foo.txt", "hello")
+
+    def test_put_multiple(self):
+        self._put_contents("bar.txt", "hi mom, how are you")
+        self._put_contents("foo.txt", "hello")
+
+    def test_put_file(self):
+        self._put_file_contents("foo.txt", "hello")
+
+    def test_put_file_multiple(self):
+        self._put_file_contents("bar.txt", "hi mom, how are you")
+        self._put_file_contents("foo.txt", "hello")
 
     def test_put_s3file(self):
         g.bucket.add_resp("/foo.txt", g.H("application/xml"), "OK!")


### PR DESCRIPTION
simples3.streaming.StreamingMixin.put_file() is missing 
```    headers = headers.copy()

```

without this, if you perform multiple put_file() calls, the second one will send an incorrect Content-Length value since the signature of put_file() uses a mutable dict as a default value to a keyword arg and is modified in the body.
```
