### PR TITLE
Fixes #14 : '&' as arguments separator.

### DIFF
--- a/simples3/bucket.py
+++ b/simples3/bucket.py
@@ -135,7 +135,7 @@ class S3Request(object):
         return self.urllib_request_cls(self.method, self.url(bucket.base_url),
                                        data=self.data, headers=self.headers)
 
-    def url(self, base_url, arg_sep=";"):
+    def url(self, base_url, arg_sep="&"):
         url = base_url + "/"
         if self.key:
             url += aws_urlquote(self.key)


### PR DESCRIPTION
#14

I guess that `;` wasn't recognized as separator so arguments has broken or `;` has unexpectedly and weirdly escaped.

``` pycon
>>> for item in storage.bucket._get_listing(args={'prefix':'1/'}): 
...     print item
... 
('1/100x100-0x0-180x180', datetime.datetime(2012, 3, 4, 3, 55, 39), '"14b4f7d62aca06f113be84a65b8c0bde"', 5059)
('1/140x140-0x0-180x180', datetime.datetime(2012, 3, 4, 3, 40, 19), '"f7eabc4177f4a4ba542d73e2baacbf60"', 8458)
('1/180x180', datetime.datetime(2012, 3, 4, 3, 40, 6), '"6a1ef466c74071e57f8e5354080153d3"', 14501)
('1/180x180-0x0-180x180', datetime.datetime(2012, 3, 4, 3, 40, 19), '"b2dc93bfa44102c981d9a92e9d6df15b"', 13184)
('1/32x32-0x0-180x180', datetime.datetime(2012, 3, 7, 6, 53, 56), '"a6c5d76151ff506f309af7c40175c136"', 906)
('1/36x36-0x0-180x180', datetime.datetime(2012, 3, 4, 3, 42, 30), '"965a76c4ff9652984625271f64b95d74"', 1238)
('1/48x48-0x0-180x180', datetime.datetime(2012, 3, 4, 3, 55, 19), '"53c2ee7bff7d42587c58748661d65d54"', 1540)
>>> for item in storage.bucket._get_listing(args={'prefix': '1/', 'max-keys': '3'}):
...     print item
... 
>>> 
```

[After replaced it with `&`](https://github.com/kimjayd/simples3/commit/700247e3d5043e35adad2dca90092ac780eba703), it works. But I am not sure using `&` as argument separator will not cause any side effects.

``` pycon
>>> for item in storage.bucket._get_listing(args={'prefix': '1/', 'max-keys': '3'}):
...     print item
... 
('1/100x100-0x0-180x180', datetime.datetime(2012, 3, 4, 3, 55, 39), '"14b4f7d62aca06f113be84a65b8c0bde"', 5059)
('1/140x140-0x0-180x180', datetime.datetime(2012, 3, 4, 3, 40, 19), '"f7eabc4177f4a4ba542d73e2baacbf60"', 8458)
('1/180x180', datetime.datetime(2012, 3, 4, 3, 40, 6), '"6a1ef466c74071e57f8e5354080153d3"', 14501)
>>> 
```
